### PR TITLE
Add integration tests for saild, and thus also sail :)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,8 @@
 name: Rust
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
+    push
+    pull_request
 
 env:
     CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,8 @@
 name: Rust
 
 on:
-    push
-    pull_request
+    push:
+    pull_request:
 
 env:
     CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,11 @@ jobs:
             - name: Cache
               uses: Swatinem/rust-cache@v2
 
+              name: Install Python
+            - uses: actions/setup-python@v6
+              with:
+                python-version: '3.12' 
+
             - name: Formatting
               run: cargo fmt --check
 
@@ -35,10 +40,8 @@ jobs:
             - name: Run unit tests
               run: cargo test
 
-            #    - name: Run integration tests
-            #      run: cargo test send_trigger -- --ignored
-            #      env:
-            #        TRIGGER_EMAIL: ${{ secrets.TRIGGER_EMAIL }}
+            - name: Run integration tests
+              run: python3 saild/test/integration_tests.py
 
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,8 +21,8 @@ jobs:
             - name: Cache
               uses: Swatinem/rust-cache@v2
 
-              name: Install Python
-            - uses: actions/setup-python@v6
+            - name: Install Python
+              uses: actions/setup-python@v6
               with:
                 python-version: '3.12' 
 

--- a/saild/src/main.rs
+++ b/saild/src/main.rs
@@ -17,6 +17,7 @@ async fn main() {
 	};
 
 	let listener = TcpListener::bind(binconf.socket_address()).await.unwrap();
+	println!("saild started, listening on {}", binconf.socket_address());
 
 	let policy = ServerPolicy {
 		hostnames: binconf.hostnames,

--- a/saild/test/abortive.txt
+++ b/saild/test/abortive.txt
@@ -1,0 +1,14 @@
+S: 220 localhost (Sail) ready
+C: EHLO test.domain
+S: 250-localhost (sail) greets test.domain
+S: 250 Help
+C: MAIL FROM:<manul@test.domain>
+S: 250 Okay
+C: RCPT TO:<snep@localhost>
+S: 250 Okay
+C: RCPT TO:<coati@localhost>
+S: 250 Okay
+C: RSET
+S: 250 Okay
+C: QUIT
+S: 221 localhost Goodbye

--- a/saild/test/happy_path.txt
+++ b/saild/test/happy_path.txt
@@ -1,0 +1,18 @@
+S: 220 localhost (Sail) ready
+C: EHLO test.domain
+S: 250-localhost (sail) greets test.domain
+S: 250 Help
+C: MAIL FROM:<Smith@test.domain>
+S: 250 Okay
+C: RCPT TO:<Jones@localhost>
+S: 250 Okay
+C: RCPT TO:<Brown@localhost>
+S: 250 Okay
+C: DATA
+S: 354 Start mail input
+C: Blah blah blah...
+C: ...etc. etc. etc.
+C: .
+S: 250
+C: QUIT
+S: 221 localhost Goodbye

--- a/saild/test/happy_path.txt
+++ b/saild/test/happy_path.txt
@@ -2,11 +2,11 @@ S: 220 localhost (Sail) ready
 C: EHLO test.domain
 S: 250-localhost (sail) greets test.domain
 S: 250 Help
-C: MAIL FROM:<Smith@test.domain>
+C: MAIL FROM:<manul@test.domain>
 S: 250 Okay
-C: RCPT TO:<Jones@localhost>
+C: RCPT TO:<snep@localhost>
 S: 250 Okay
-C: RCPT TO:<Brown@localhost>
+C: RCPT TO:<coati@localhost>
 S: 250 Okay
 C: DATA
 S: 354 Start mail input

--- a/saild/test/integration_tests.py
+++ b/saild/test/integration_tests.py
@@ -28,6 +28,11 @@ class TestCase:
         
         i = 1
         while i < len(testlines):
+            if not testlines[i].startswith("C: ") and not testlines[i].startswith("S: "):
+                # invalid line
+                i += 1
+                continue
+
             command = Command([], [])
             while i < len(testlines) and testlines[i].startswith("C: "):
                 command.command.append(testlines[i][3:].strip())

--- a/saild/test/integration_tests.py
+++ b/saild/test/integration_tests.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TextIO
 from itertools import chain
 
-testfiles = ["happy_path.txt"]
+testfiles = ["happy_path.txt", "abortive.txt"]
 process: subprocess.Popen = subprocess.Popen([shutil.which("cargo"), "run"], stdout=subprocess.PIPE, stderr=subprocess.PIPE) # type: ignore
 is_error: bool = True
 
@@ -115,7 +115,7 @@ def test(sail_fd: TextIO, testfile_name: str, generate: bool, codes_only: bool):
         print(generated_text)
         with open(testfile_name, "w") as testfile:
             testfile.write(generated_text)
-    print("Completed test with no problems :)")
+    print(f"Completed test {testfile_name.split("/")[-1]} with no problems :)")
 
 def run_tests(generate: bool, codes_only: bool):
     sail = start_sail()

--- a/saild/test/integration_tests.py
+++ b/saild/test/integration_tests.py
@@ -1,0 +1,65 @@
+import subprocess, shutil, socket, sys
+from typing import Optional, TextIO
+
+testfiles = ["happy_path.txt"]
+process: subprocess.Popen = subprocess.Popen([shutil.which("cargo"), "run"], stdout=subprocess.PIPE, stderr=subprocess.PIPE) # type: ignore
+
+# returns a tuple of address and port
+def start_sail() -> Optional[tuple[str, int]]:
+    if process.stdout == None:
+        print("failed to start sail process")
+        return None
+
+    first_bytes: bytes = process.stdout.readline()
+    first_line: str = first_bytes.decode()
+    if not first_line.startswith("saild started"):
+        print("error initializing: " + first_line)
+        return None
+    
+    socket_address = first_line.split(" ")[-1].split(":")
+    return socket_address[0], int(socket_address[1])
+
+
+def init_socket(address: str, port: int) -> Optional[TextIO]:
+    
+    sail_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sail_socket.connect((address, port))
+    return sail_socket.makefile("rw")
+
+def test(sail_fd: TextIO, testfile: TextIO):
+    for line in testfile:
+        print("test line: " + line.removesuffix("\n"))
+        next_line = sanitize_newlines(line)
+        if next_line.startswith("S:"):
+            expected_response = next_line.replace("S: ", "")
+            sail_response = sanitize_newlines(sail_fd.readline())
+            print("sail response: " + sail_response)
+
+            if sail_response != expected_response:
+                print(f"Diff test failed: sail vs expected: \n{sail_response}\n{expected_response}")
+                return -1
+        elif next_line.startswith("C:"):
+            sail_fd.write(next_line.replace("C: ", "").replace("\\r", "").replace("\\n", "") + "\r\n")
+            sail_fd.flush()
+    print("Completed test with no problems :)")
+
+def sanitize_newlines(input: str) -> str:
+    return input.replace("\r", "\\r").replace("\n", "\\n")
+
+def run_tests():
+    sail = start_sail()
+    if sail is None:
+        return None
+    
+    for testfile in testfiles:
+        socket = init_socket(sail[0], sail[1])
+        if socket is None:
+            return None
+        
+        test(socket, open("saild/test/" + testfile))
+
+try:
+    run_tests()
+finally:
+    if process is not None:
+        process.kill()


### PR DESCRIPTION
this is a solid integration testing strategy IMO, as long as we believe saild should be a flagship implementation / example, i.e. it supports most valid usecases, or enough to reasonably cover sail

todo:

- [x] more test cases
- [x] testcase (re)generator - supply the client data and the generator records saild's responses to make a new testcase
- [x] ignore text, only check response codes in integration tests